### PR TITLE
ci: add build workflow for Renovate PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Test
+        run: cargo test --all-targets

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    io::{Error, ErrorKind, Result},
+    io::{Error, Result},
     num::ParseIntError,
 };
 
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     let port = match env::var("PORT") {
         Ok(v) => v
             .parse()
-            .map_err(|e: ParseIntError| Error::new(ErrorKind::Other, e.to_string()))?,
+            .map_err(|e: ParseIntError| Error::other(e.to_string()))?,
         Err(_) => 8080,
     };
 


### PR DESCRIPTION
## Summary
- Add a CI workflow that triggers on PRs and pushes to main
- Runs `cargo fmt`, `clippy`, `build`, and `test` with stable Rust
- Ensures Renovate dependency upgrade PRs get a build status (pass/fail)